### PR TITLE
Add new deployment feature and allow configmap to be optional

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 name: swaggerui
-version: 0.2.0
+version: 0.3.0
 appVersion: 3.24.3
 description: Swagger is an open-source software framework backed by a large ecosystem of tools that helps developers design, build, document, and consume RESTful Web services.
 keywords:

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ The following table lists the configurable parameters of the swagger-ui chart an
 | `swagger-ui.jsonUrl`                                                        | location of the configuration json file file                                                                       | `http://petstore.swagger.io/v2/swagger.json` |
 | `swagger-ui.server.url`                                                     | Url of a custom server                                                                                             | `"http://www.google.be"`        |
 | `swagger-ui.server.description`                                             | descripton of a custom server                                                                                      | `"helm-online"`                 |
+| **Deployment**                                                              |
+| `deployment.replicas`                                                       | Number of replicas                                                                                                 | `1`                             |
+| `deployment.extraEnv`                                                       | Additional environment variable                                                                                    | ``                              |
 | **Service**                                                                 |
 | `service.type`                                                              | Type of service for swagger-ui frontend                                                                            | `NodePort`                      |
 | `service.port`                                                              | Port to expose service                                                                                             | `8080`                          |
@@ -78,7 +81,7 @@ The following table lists the configurable parameters of the swagger-ui chart an
 | `ingress.tls`                                                               | Ingress TLS configuration                                                                                          | `[]`                            |
 | **ReadinessProbe**                                                          |
 | `readinessProbe`                                                            | Rediness Probe settings                                                                                            | `nil`                           |
-| **LivenessProbe**                                                           | 
+| **LivenessProbe**                                                           |
 | `livenessProbe.httpGet.path`                                                | Liveness Probe settings                                                                                            | `/`                             |
 | `livenessProbe.httpGet.port`                                                | Liveness Probe settings                                                                                            | `http`                          |
 | `livenessProbe.initialDelaySeconds`                                         | Liveness Probe settings                                                                                            | `60`                            |

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.swaggerui.jsonPath }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -10,3 +11,4 @@ metadata:
     heritage: {{ .Release.Service | quote }}
 data:
   conf.json: {{ .Files.Get (printf "%s" .Values.swaggerui.jsonPath) | toJson | indent 4}}
+{{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           args : {{ (printf "[\"mkdir /api-doc && wget %s -O /api-doc/openapi.json && apk update && apk add jq && jq '.servers += [{\\\"url\\\":\\\"%s\\\",\\\"description\\\":\\\"%s\\\"}]' /api-doc/openapi.json > json.tmp && mv json.tmp /api-doc/openapi.json && /usr/share/nginx/run.sh\"]" .Values.swaggerui.jsonUrl .Values.swaggerui.server.url .Values.swaggerui.server.description ) }} {{ end }}
           env:
           {{- with .Values.deployment.extraEnv }}
-          {{- toYaml . | nindent 8 }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
           - name: SWAGGER_JSON
             value: /api-doc/openapi.json

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.deployment.replicas | default 1 }}
   selector:
     matchLabels:
       app: {{ template "swagger-ui.name" . }}
@@ -32,6 +32,9 @@ spec:
           command: ["/bin/sh","-c"]
           args : {{ (printf "[\"mkdir /api-doc && wget %s -O /api-doc/openapi.json && apk update && apk add jq && jq '.servers += [{\\\"url\\\":\\\"%s\\\",\\\"description\\\":\\\"%s\\\"}]' /api-doc/openapi.json > json.tmp && mv json.tmp /api-doc/openapi.json && /usr/share/nginx/run.sh\"]" .Values.swaggerui.jsonUrl .Values.swaggerui.server.url .Values.swaggerui.server.description ) }} {{ end }}
           env:
+          {{- with .Values.deployment.extraEnv }}
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
           - name: SWAGGER_JSON
             value: /api-doc/openapi.json
           livenessProbe:

--- a/values.yaml
+++ b/values.yaml
@@ -16,6 +16,14 @@ swaggerui :
     url: http://www.google.be
     description: "helm-online"
 
+## Set the number of replicas on the swaggerui deployment.
+##
+deployment:
+  replicas: 1
+  extraEnv:
+  # - name: BASE_URL
+  #   value: /swagger
+
 ## Expose the swagger-ui service and
 ## Provides options for the service so chart users have the full choice
 ## Set the service type and the port to serve it.

--- a/values.yaml
+++ b/values.yaml
@@ -16,7 +16,7 @@ swaggerui :
     url: http://www.google.be
     description: "helm-online"
 
-## Set the number of replicas on the swaggerui deployment.
+## Configure the deployment resource 
 ##
 deployment:
   replicas: 1


### PR DESCRIPTION

#### What this PR does / why we need it:
Mainly this was some feature I needed for my deployment.

- Being able to configure the number of replicas
- Not having a empty configmap when you are not using the `jsonPath` value
- Being able to add new environment variable to the deployment, I needed the `BASE_URL` environment variable from swagger docker image in my deployment.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
