### PR TITLE
Fix containerPort in deployment.yaml

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
               port: {{ .Values.livenessProbe.httpGet.port }}
           ports:
           - name: http
-            containerPort: {{ .Values.service.port }}
+            containerPort: 8080
             protocol: TCP
       {{- if .Values.swaggerui.jsonPath }}
       volumes:


### PR DESCRIPTION
<!--
Thank you for contributing to this repository. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
the review guidelines form the Helm repository:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
The container is always listening on the 8080 port:
https://github.com/swagger-api/swagger-ui/blob/master/docker/nginx.conf#L27

So the `containerPort` in the chart's deployment must reference that value.

That way, changing `service.port` has the expected behaviour: make the service listen to whatever port you decide (80:8080 for example)

#### Which issue this PR fixes

#### Special notes for your reviewer:
Deploy the chart without values then with
```yaml
service:
  type: ClusterIP
  port: 80
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
