### PR TITLE
Use new ingress apiVersion if available

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -2,7 +2,11 @@
 {{- if .Values.ingress.enabled }}
 {{- $fullName := include "swagger-ui.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
 apiVersion: extensions/v1beta1
+{{ end -}}
 kind: Ingress
 metadata:
   name: {{ template "swagger-ui.fullname" . }}


### PR DESCRIPTION
`extensions/v1beta1` has been replaced by `networking.k8s.io/v1beta1` starting in v1.14.0 and will be removed in v1.22.0