### PR TITLE
Adds HPA and support for local https sites

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: swaggerui
-version: 0.3.2
+version: 0.3.3
 appVersion: 3.24.3
 description: Swagger is an open-source software framework backed by a large ecosystem of tools that helps developers design, build, document, and consume RESTful Web services.
 keywords:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             name: swagger-config
           {{ else }}
           command: ["/bin/sh","-c"]
-          args : {{ (printf "[\"mkdir /api-doc && wget %s -O /api-doc/openapi.json && apk update && apk add jq && jq '.servers += [{\\\"url\\\":\\\"%s\\\",\\\"description\\\":\\\"%s\\\"}]' /api-doc/openapi.json > json.tmp && mv json.tmp /api-doc/openapi.json && /usr/share/nginx/run.sh\"]" .Values.swaggerui.jsonUrl .Values.swaggerui.server.url .Values.swaggerui.server.description ) }} {{ end }}
+          args : {{ (printf "[\"mkdir /api-doc && wget --no-check-certificate %s -O /api-doc/openapi.json && apk update && apk add jq && jq '.servers += [{\\\"url\\\":\\\"%s\\\",\\\"description\\\":\\\"%s\\\"}]' /api-doc/openapi.json > json.tmp && mv json.tmp /api-doc/openapi.json && /usr/share/nginx/run.sh\"]" .Values.swaggerui.jsonUrl .Values.swaggerui.server.url .Values.swaggerui.server.description ) }} {{ end }}
           env:
           {{- with .Values.deployment.extraEnv }}
           {{- toYaml . | nindent 10 }}
@@ -48,6 +48,8 @@ spec:
           - name: http
             containerPort: 8080
             protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
       {{- if .Values.swaggerui.jsonPath }}
       volumes:
         - name: swagger-config

--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "swagger-ui.fullname" . }}
+  labels:
+    app: {{ template "swagger-ui.name" . }}
+    chart: {{ template "swagger-ui.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "swagger-ui.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -79,6 +79,13 @@ livenessProbe:
   periodSeconds: 30
   timeoutSeconds: 10
 
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##


### PR DESCRIPTION
I'm using swagger UI with a local service that exposes a `https` endpoint. As it's running in the same kubernetes cluster and namespace I can access it with _https://SERVICE-NAME_. Unfortunately the `wget` command fails because it's not a FQDN and the SSL verification cannot be done.

I'm also adding the HPA template for users wanting to do autoscaling.