### PR TITLE
Update Ingress to use networking.k8s.io/v1 (#21)

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: swaggerui
-version: 0.3.4
+version: 0.3.5
 appVersion: 3.24.3
 description: Swagger is an open-source software framework backed by a large ecosystem of tools that helps developers design, build, document, and consume RESTful Web services.
 keywords:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -2,7 +2,9 @@
 {{- if .Values.ingress.enabled }}
 {{- $fullName := include "swagger-ui.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
 {{ else }}
 apiVersion: extensions/v1beta1
@@ -36,8 +38,17 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+            pathType: "ImplementationSpecific"
+            backend:
+              service:
+                name:  {{ $fullName }}
+                port:
+                  name: http
+{{- else }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: http
-  {{- end }}
+{{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to this repository. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
the review guidelines form the Helm repository:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Updates the chart to use the a non-deprecated ingress api. I tried to do it in a backwards compatible way for cluster <1.19. I tested the change on my cluster with version 1.21.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #21 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped

